### PR TITLE
underscore mangler

### DIFF
--- a/src/TestSchema.ts
+++ b/src/TestSchema.ts
@@ -4,6 +4,7 @@ export interface WgslTestSrc {
   weslSrc: Record<string, string>;  // source wesl+ texts, keys are file paths
   notes?: string;                   // additional notes to test implementors
   expectedWgsl?: string;            // expected linked result wgsl 
+  underscoreWgsl?: string;          // expected linked result wgsl using underscore mangler
 }
 
 export interface ParsingTest {

--- a/src/test-cases-json/importCases.json
+++ b/src/test-cases-json/importCases.json
@@ -5,14 +5,16 @@
       "./main.wgsl": "\n          import package::bar::foo;\n          fn main() {\n            foo();\n          }\n       ",
       "./bar.wgsl": "\n          fn foo() { }\n       "
     },
-    "expectedWgsl": "\n      fn main() {\n        foo();\n      }\n\n      fn foo() { }\n    "
+    "expectedWgsl": "\n      fn main() {\n        foo();\n      }\n\n      fn foo() { }\n    ",
+    "underscoreWgsl": "\n      fn main() {\n        __bar_foo();\n      }\n\n      fn __bar_foo() { }\n    "
   },
   {
     "name": "main has other root elements",
     "weslSrc": {
       "./main.wgsl": "\n          struct Uniforms {\n            a: u32\n          }\n\n          @group(0) @binding(0) var<uniform> u: Uniforms;\n\n          fn main() { }\n      "
     },
-    "expectedWgsl": "\n      struct Uniforms {\n        a: u32\n      }\n\n      @group(0) @binding(0) var<uniform> u: Uniforms;\n\n      fn main() { }\n    "
+    "expectedWgsl": "\n      struct Uniforms {\n        a: u32\n      }\n\n      @group(0) @binding(0) var<uniform> u: Uniforms;\n\n      fn main() { }\n    ",
+    "underscoreWgsl": "\n      struct Uniforms {\n        a: u32\n      }\n\n      @group(0) @binding(0) var<uniform> u: Uniforms;\n\n      fn main() { }\n    "
   },
   {
     "name": "import foo as bar",
@@ -20,7 +22,8 @@
       "./main.wgsl": "\n        import package::file1::foo as bar;\n\n        fn main() {\n          bar();\n        }\n      ",
       "./file1.wgsl": "\n        fn foo() { /* fooImpl */ }\n      "
     },
-    "expectedWgsl": "\n      fn main() {\n        bar();\n      }\n\n      fn bar() { /* fooImpl */ }\n    "
+    "expectedWgsl": "\n      fn main() {\n        bar();\n      }\n\n      fn bar() { /* fooImpl */ }\n    ",
+    "underscoreWgsl": "\n      fn main() {\n        __file1_foo();\n      }\n\n      fn __file1_foo() { /* fooImpl */ }\n    "
   },
   {
     "name": "import twice doesn't get two copies",
@@ -29,7 +32,8 @@
       "./file1.wgsl": "\n        fn foo() { /* fooImpl */ }\n      ",
       "./file2.wgsl": "\n        import package::file1::foo;\n        fn bar() { foo(); }\n      "
     },
-    "expectedWgsl": "\n      fn main() {\n        foo();\n        bar();\n      }\n\n      fn foo() { /* fooImpl */ }\n\n      fn bar() { foo(); }\n    "
+    "expectedWgsl": "\n      fn main() {\n        foo();\n        bar();\n      }\n\n      fn foo() { /* fooImpl */ }\n\n      fn bar() { foo(); }\n    ",
+    "underscoreWgsl": "\n      fn main() {\n        __file1_foo();\n        __file2_bar();\n      }\n\n      fn __file1_foo() { /* fooImpl */ }\n\n      fn __file2_bar() { __file1_foo(); }\n    "
   },
   {
     "name": "imported fn calls support fn with root conflict",
@@ -37,7 +41,8 @@
       "./main.wgsl": "\n        import package::file1::foo; \n\n        fn main() { foo(); }\n        fn conflicted() { }\n      ",
       "./file1.wgsl": "\n        fn foo() {\n          conflicted(0);\n          conflicted(1);\n        }\n        fn conflicted(a:i32) {}\n      "
     },
-    "expectedWgsl": "\n      fn main() { foo(); }\n\n      fn conflicted() { }\n\n      fn foo() {\n        conflicted0(0);\n        conflicted0(1);\n      }\n\n      fn conflicted0(a:i32) {}\n    "
+    "expectedWgsl": "\n      fn main() { foo(); }\n\n      fn conflicted() { }\n\n      fn foo() {\n        conflicted0(0);\n        conflicted0(1);\n      }\n\n      fn conflicted0(a:i32) {}\n    ",
+    "underscoreWgsl": "\n      fn main() { __file1_foo(); }\n\n      fn conflicted() { }\n\n      fn __file1_foo() {\n        __file1_conflicted(0);\n        __file1_conflicted(1);\n      }\n\n      fn __file1_conflicted(a:i32) {}\n    "
   },
   {
     "name": "import twice with two as names",
@@ -45,7 +50,8 @@
       "./main.wgsl": "\n        import package::file1::foo as bar;\n        import package::file1::foo as zap;\n\n        fn main() { bar(); zap(); }\n      ",
       "./file1.wgsl": "\n        fn foo() { }\n      "
     },
-    "expectedWgsl": "\n      fn main() { bar(); bar(); }\n\n      fn bar() { }\n    "
+    "expectedWgsl": "\n      fn main() { bar(); bar(); }\n\n      fn bar() { }\n    ",
+    "underscoreWgsl": "\n      fn main() { __file1_foo(); __file1_foo(); }\n\n      fn __file1_foo() { }\n    "
   },
   {
     "name": "import transitive conflicts with main",
@@ -54,7 +60,8 @@
       "./file1.wgsl": "\n        import package::file2::grand;\n        \n        fn mid() { grand(); }\n      ",
       "./file2.wgsl": "\n        fn grand() { /* grandImpl */ }\n      "
     },
-    "expectedWgsl": "\n      fn main() {\n        mid();\n      }\n\n      fn grand() {\n        /* main impl */\n      }\n\n      fn mid() { grand0(); }\n\n      fn grand0() { /* grandImpl */ }\n    "
+    "expectedWgsl": "\n      fn main() {\n        mid();\n      }\n\n      fn grand() {\n        /* main impl */\n      }\n\n      fn mid() { grand0(); }\n\n      fn grand0() { /* grandImpl */ }\n    ",
+    "underscoreWgsl": "\n      fn main() {\n        __file1_mid();\n      }\n\n      fn grand() {\n        /* main impl */\n      }\n\n      fn __file1_mid() { __file2_grand(); }\n\n      fn __file2_grand() { /* grandImpl */ }\n    "
   },
   {
     "name": "multiple exports from the same module",
@@ -62,7 +69,8 @@
       "./main.wgsl": "\n        import package::file1::{foo, bar};\n\n        fn main() {\n          foo();\n          bar();\n        }\n      ",
       "./file1.wgsl": "\n        fn foo() { }\n        fn bar() { }\n      "
     },
-    "expectedWgsl": "\n      fn main() {\n        foo();\n        bar();\n      }\n\n      fn foo() { }\n\n      fn bar() { }\n    "
+    "expectedWgsl": "\n      fn main() {\n        foo();\n        bar();\n      }\n\n      fn foo() { }\n\n      fn bar() { }\n    ",
+    "underscoreWgsl": "\n      fn main() {\n        __file1_foo();\n        __file1_bar();\n      }\n\n      fn __file1_foo() { }\n\n      fn __file1_bar() { }\n    "
   },
   {
     "name": "import and resolve conflicting support function",
@@ -70,7 +78,8 @@
       "./main.wgsl": "\n        import package::file1::foo as bar;\n\n        fn support() { \n          bar();\n        }\n      ",
       "./file1.wgsl": "\n        fn foo() {\n          support();\n        }\n\n        fn support() { }\n      "
     },
-    "expectedWgsl": "\n      fn support() {\n        bar();\n      }\n\n      fn bar() {\n        support0();\n      }\n\n      fn support0() { }\n    "
+    "expectedWgsl": "\n      fn support() {\n        bar();\n      }\n\n      fn bar() {\n        support0();\n      }\n\n      fn support0() { }\n    ",
+    "underscoreWgsl": "\n      fn support() {\n        __file1_foo();\n      }\n\n      fn __file1_foo() {\n        __file1_support();\n      }\n\n      fn __file1_support() { }\n    "
   },
   {
     "name": "import support fn that references another import",
@@ -79,7 +88,8 @@
       "./file1.wgsl": "\n        import package::file2::bar;\n\n        fn foo() {\n          support();\n          bar();\n        }\n\n        fn support() { }\n      ",
       "./file2.wgsl": "\n        fn bar() {\n          support();\n        }\n\n        fn support() { }\n      "
     },
-    "expectedWgsl": "\n      fn support() {\n        foo();\n      }\n\n      fn foo() {\n        support0();\n        bar();\n      }\n\n      fn support0() { }\n\n      fn bar() {\n        support1();\n      }\n\n      fn support1() { }\n    "
+    "expectedWgsl": "\n      fn support() {\n        foo();\n      }\n\n      fn foo() {\n        support0();\n        bar();\n      }\n\n      fn support0() { }\n\n      fn bar() {\n        support1();\n      }\n\n      fn support1() { }\n    ",
+    "underscoreWgsl": "\n      fn support() {\n        __file1_foo();\n      }\n\n      fn __file1_foo() {\n        __file1_support();\n        __file2_bar();\n      }\n\n      fn __file1_support() { }\n\n      fn __file2_bar() {\n        __file2_support();\n      }\n\n      fn __file2_support() { }\n    "
   },
   {
     "name": "import support fn from two exports",
@@ -87,7 +97,8 @@
       "./main.wgsl": "\n        import package::file1::foo;\n        import package::file1::bar;\n        fn main() {\n          foo();\n          bar();\n        }\n      ",
       "./file1.wgsl": "\n        fn foo() {\n          support();\n        }\n\n        fn bar() {\n          support();\n        }\n\n        fn support() { }\n      "
     },
-    "expectedWgsl": "\n      fn main() {\n        foo();\n        bar();\n      }\n\n      fn foo() {\n        support();\n      }\n\n      fn bar() {\n        support();\n      }\n\n      fn support() { }\n    "
+    "expectedWgsl": "\n      fn main() {\n        foo();\n        bar();\n      }\n\n      fn foo() {\n        support();\n      }\n\n      fn bar() {\n        support();\n      }\n\n      fn support() { }\n    ",
+    "underscoreWgsl": "\n      fn main() {\n        __file1_foo();\n        __file1_bar();\n      }\n\n      fn __file1_foo() {\n        __file1_support();\n      }\n\n      fn __file1_bar() {\n        __file1_support();\n      }\n\n      fn __file1_support() { }\n    "
   },
   {
     "name": "import a struct",
@@ -96,7 +107,8 @@
       "./file1.wgsl": "\n        struct AStruct {\n          x: u32,\n        }\n      ",
       "./file2.wgsl": "\n      "
     },
-    "expectedWgsl": "\n      fn main() {\n        let a = AStruct(1u);\n      }\n\n      struct AStruct {\n        x: u32,\n      }\n    "
+    "expectedWgsl": "\n      fn main() {\n        let a = AStruct(1u);\n      }\n\n      struct AStruct {\n        x: u32,\n      }\n    ",
+    "underscoreWgsl": "\n      fn main() {\n        let a = __file1_AStruct(1u);\n      }\n\n      struct __file1_AStruct {\n        x: u32,\n      }\n      "
   },
   {
     "name": "import fn with support struct constructor",
@@ -105,7 +117,8 @@
       "./file1.wgsl": "\n        struct Elem {\n          sum: u32\n        }\n\n        fn elemOne() -> Elem {\n          return Elem(1u);\n        }\n      ",
       "./file2.wgsl": "\n      "
     },
-    "expectedWgsl": "\n      fn main() {\n        let ze = elemOne();\n      }\n\n      fn elemOne() -> Elem {\n        return Elem(1u);\n      }\n\n      struct Elem {\n        sum: u32\n      }\n    "
+    "expectedWgsl": "\n      fn main() {\n        let ze = elemOne();\n      }\n\n      fn elemOne() -> Elem {\n        return Elem(1u);\n      }\n\n      struct Elem {\n        sum: u32\n      }\n    ",
+    "underscoreWgsl": "\n      fn main() {\n        let ze = __file1_elemOne();\n      }\n      fn __file1_elemOne() -> __file1_Elem {\n        return __file1_Elem(1u);\n      }\n      struct __file1_Elem {\n        sum: u32\n      }\n    "
   },
   {
     "name": "import a transitive struct",
@@ -114,7 +127,8 @@
       "./file1.wgsl": "\n        import package::file2::BStruct;\n\n        struct AStruct {\n          s: BStruct,\n        }\n      ",
       "./file2.wgsl": "\n        struct BStruct {\n          x: u32,\n        }\n      "
     },
-    "expectedWgsl": "\n      struct SrcStruct {\n        a: AStruct,\n      }\n\n      struct AStruct {\n        s: BStruct,\n      }\n\n      struct BStruct {\n        x: u32,\n      }\n    "
+    "expectedWgsl": "\n      struct SrcStruct {\n        a: AStruct,\n      }\n\n      struct AStruct {\n        s: BStruct,\n      }\n\n      struct BStruct {\n        x: u32,\n      }\n    ",
+    "underscoreWgsl": "\n      struct SrcStruct {\n        a: __file1_AStruct,\n      }\n      struct __file1_AStruct {\n        s: __file2_BStruct,\n      }\n      struct __file2_BStruct {\n        x: u32,\n      }\n    "
   },
   {
     "name": "'import as' a struct",
@@ -122,7 +136,8 @@
       "./main.wgsl": "\n        import package::file1::AStruct as AA;\n\n        fn foo (a: AA) { }\n      ",
       "./file1.wgsl": "\n        struct AStruct { x: u32 }\n      "
     },
-    "expectedWgsl": "\n      fn foo (a: AA) { }\n\n      struct AA { x: u32 }\n    "
+    "expectedWgsl": "\n      fn foo (a: AA) { }\n\n      struct AA { x: u32 }\n    ",
+    "underscoreWgsl": "\n      fn foo (a: __file1_AStruct) { }\n      struct __file1_AStruct { x: u32 }\n    "
   },
   {
     "name": "import a struct with name conflicting support struct",
@@ -130,7 +145,8 @@
       "./main.wgsl": "\n        import package::file1::AStruct;\n\n        struct Base {\n          b: i32\n        }\n\n        fn foo() -> AStruct {var a:AStruct; return a;}\n      ",
       "./file1.wgsl": "\n        struct Base {\n          x: u32\n        }\n\n        struct AStruct {\n          x: Base\n        }\n      "
     },
-    "expectedWgsl": "\n      struct Base {\n        b: i32\n      }\n\n      fn foo() -> AStruct {var a:AStruct; return a;}\n\n      struct AStruct {\n        x: Base0\n      }\n\n      struct Base0 {\n        x: u32\n      }\n    "
+    "expectedWgsl": "\n      struct Base {\n        b: i32\n      }\n\n      fn foo() -> AStruct {var a:AStruct; return a;}\n\n      struct AStruct {\n        x: Base0\n      }\n\n      struct Base0 {\n        x: u32\n      }\n    ",
+    "underscoreWgsl": "\n      struct Base {\n        b: i32\n      }\n      fn foo() -> __file1_AStruct {var a:__file1_AStruct; return a;}\n      struct __file1_AStruct {\n        x: __file1_Base\n      }\n      struct __file1_Base {\n        x: u32\n      }\n    "
   },
   {
     "name": "copy alias to output",
@@ -152,7 +168,8 @@
       "./main.wgsl": "\n        import package::file1::foo;\n\n        fn main() { foo(); }\n      ",
       "./file1.wgsl": "\n        struct AStruct {\n          x: u32\n        }\n        fn foo(a: AStruct) {\n          let b = a.x;\n        }\n      "
     },
-    "expectedWgsl": "\n        fn main() { foo(); }\n\n        fn foo(a: AStruct) { \n          let b = a.x;\n        }\n\n        struct AStruct {\n          x: u32\n        }\n    "
+    "expectedWgsl": "\n        fn main() { foo(); }\n\n        fn foo(a: AStruct) { \n          let b = a.x;\n        }\n\n        struct AStruct {\n          x: u32\n        }\n    ",
+    "underscoreWgsl": "\n      fn main() { __file1_foo(); }\n      fn __file1_foo(a: __file1_AStruct) {\n        let b = a.x;\n      }\n      struct __file1_AStruct {\n        x: u32\n      }\n    "
   },
   {
     "name": "const referenced by imported fn",
@@ -160,7 +177,8 @@
       "./main.wgsl": "\n        import package::file1::foo;\n\n        fn main() { foo(); }\n      ",
       "./file1.wgsl": "\n        const conA = 7;\n\n        fn foo() {\n          let a = conA;\n        }\n      "
     },
-    "expectedWgsl": "\n        fn main() { foo(); }\n\n        fn foo() {\n          let a = conA;\n        }\n\n        const conA = 7;\n    "
+    "expectedWgsl": "\n        fn main() { foo(); }\n\n        fn foo() {\n          let a = conA;\n        }\n\n        const conA = 7;\n    ",
+    "underscoreWgsl": "\n      fn main() { __file1_foo(); }\n      fn __file1_foo() {\n        let a = __file1_conA;\n      }\n      const __file1_conA = 7;\n    "
   },
   {
     "name": "fn call with a separator",
@@ -168,7 +186,8 @@
       "./main.wgsl": "\n        import package::file1::foo;\n\n        fn main() { foo::bar(); }\n      ",
       "./file1/foo.wgsl": "\n        fn bar() { }\n      "
     },
-    "expectedWgsl": "\n        fn main() { bar(); }\n\n        fn bar() { }\n    "
+    "expectedWgsl": "\n      fn main() { bar(); }\n\n      fn bar() { }\n    ",
+    "underscoreWgsl": "\n      fn main() { __file1_foo_bar(); }\n      fn __file1_foo_bar() { }\n    "
   },
   {
     "name": "local var to struct",
@@ -176,7 +195,8 @@
       "./main.wgsl": "\n        import package::file1::AStruct;\n\n        fn main() {\n          var a: AStruct; \n        }\n      ",
       "./file1.wgsl": "\n        struct AStruct { x: u32 }\n      "
     },
-    "expectedWgsl": "\n        fn main() {\n          var a: AStruct; \n        }\n        struct AStruct { x: u32 }\n    "
+    "expectedWgsl": "\n        fn main() {\n          var a: AStruct; \n        }\n        struct AStruct { x: u32 }\n    ",
+    "underscoreWgsl": "\n        fn main() {\n          var a: __file1_AStruct;\n        }\n        struct __file1_AStruct { x: u32 }\n    "
   },
   {
     "name": "global var to struct",
@@ -184,7 +204,8 @@
       "./main.wgsl": "\n        import package::file1::Uniforms;\n\n        @group(0) @binding(0) var<uniform> u: Uniforms;      \n      ",
       "./file1.wgsl": "\n        struct Uniforms { model: mat4x4<f32> }\n      "
     },
-    "expectedWgsl": "\n        @group(0) @binding(0) var<uniform> u: Uniforms;      \n        struct Uniforms { model: mat4x4<f32> }\n    "
+    "expectedWgsl": "\n        @group(0) @binding(0) var<uniform> u: Uniforms;      \n        struct Uniforms { model: mat4x4<f32> }\n    ",
+    "underscoreWgsl": "\n        @group(0) @binding(0) var<uniform> u: __file1_Uniforms;\n        struct __file1_Uniforms { model: mat4x4<f32> }\n    "
   },
   {
     "name": "return type of function",
@@ -192,7 +213,8 @@
       "./main.wgsl": "\n        import package::file1::A;\n\n        fn b() -> A { }\n      ",
       "./file1.wgsl": "\n        struct A { y: i32 }\n      "
     },
-    "expectedWgsl": "\n        fn b() -> A { }\n        struct A { y: i32 }\n    "
+    "expectedWgsl": "\n        fn b() -> A { }\n        struct A { y: i32 }\n    ",
+    "underscoreWgsl": "\n        fn b() -> __file1_A { }\n        struct __file1_A { y: i32 }\n    "
   },
   {
     "name": "import a const",
@@ -200,7 +222,8 @@
       "./main.wgsl": "\n        import package::file1::conA;\n\n        fn m() { let a = conA; }\n      ",
       "./file1.wgsl": "\n        const conA = 11;\n      "
     },
-    "expectedWgsl": "\n        fn m() { let a = conA; }\n        const conA = 11;\n    "
+    "expectedWgsl": "\n        fn m() { let a = conA; }\n        const conA = 11;\n    ",
+    "underscoreWgsl": "\n        fn m() { let a = __file1_conA; }\n        const __file1_conA = 11;\n    "
   },
   {
     "name": "import an alias",
@@ -208,7 +231,8 @@
       "./main.wgsl": "\n        import package::file1::aliasA;\n\n        fn m() { let a: aliasA = 4; }\n      ",
       "./file1.wgsl": "\n        alias aliasA = u32;\n      "
     },
-    "expectedWgsl": "\n        fn m() { let a: aliasA = 4; }\n        alias aliasA = u32;\n    "
+    "expectedWgsl": "\n        fn m() { let a: aliasA = 4; }\n        alias aliasA = u32;\n    ",
+    "underscoreWgsl": "\n        fn m() { let a: __file1_aliasA = 4; }\n        alias __file1_aliasA = u32;\n    "
   },
   {
     "name": "alias f32",
@@ -216,7 +240,8 @@
       "./main.wgsl": "\n      import package::file1::foo;\n      fn main() { foo(); }\n      ",
       "./file1.wgsl": "\n      struct AStruct { x: u32 }\n      alias f32 = AStruct;\n      fn foo(a: f32) { }\n      "
     },
-    "expectedWgsl": "\n      fn main() { foo(); }\n      fn foo(a: f32) { }\n      alias f32 = AStruct;\n      struct AStruct { x: u32 }\n    "
+    "expectedWgsl": "\n      fn main() { foo(); }\n      fn foo(a: f32) { }\n      alias f32 = AStruct;\n      struct AStruct { x: u32 }\n    ",
+    "underscoreWgsl": "\n      fn main() { __file1_foo(); }\n      fn __file1_foo(a: __file1_f32) { }\n      alias __file1_f32 = __file1_AStruct;\n      struct __file1_AStruct { x: u32 }\n    "
   },
   {
     "name": "fn f32()",
@@ -225,6 +250,17 @@
       "./file1.wgsl": "\n      fn f32() { }\n      fn foo() { f32(); }\n      ",
       "./file2.wgsl": "\n      "
     },
-    "expectedWgsl": "\n      fn main() { foo(); }\n      fn foo() { f32(); }\n      fn f32() { }\n    "
+    "expectedWgsl": "\n      fn main() { foo(); }\n      fn foo() { f32(); }\n      fn f32() { }\n    ",
+    "underscoreWgsl": "\n      fn main() { __file1_foo(); }\n      fn __file1_foo() { __file1_f32(); }\n      fn __file1_f32() { }\n    "
+  },
+  {
+    "name": "circular import",
+    "weslSrc": {
+      "./main.wgsl": "\n      import package::file1::foo;\n      fn main() { foo(); }\n      ",
+      "./file1.wgsl": "\n      import package::file2::bar;\n      fn foo() { bar(); }\n      fn fie() {}\n      ",
+      "./file2.wgsl": "\n      import package::file1::fie;\n      fn bar() { fie(); }\n      "
+    },
+    "expectedWgsl": "\n      fn main() { foo(); }\n      fn foo() { bar(); }\n      fn bar() { fie(); }\n      fn fie() {}\n    ",
+    "underscoreWgsl": "\n      fn main() { __file1_foo(); }\n      fn __file1_foo() { __file2_bar(); }\n      fn __file2_bar() { __file1_fie(); }\n      fn __file1_fie() {}\n    "
   }
 ]


### PR DESCRIPTION
Update test cases to also show the `underscoreMangler` expected results, intended for sharing test cases between wesl-rs and wesl-js.

There are now two versions of results, one with the wesl-js `minimalMangler` which tries to mangle as little as possible but isn't fully characterized for sharing tests, and one with the `underscoreMangler` which is fully characterized but creates less attractive wgsl. This PR creates a way to share tests for now, perhaps in the future we can drop one of these schemes.

Probably useful to look at one or two example cases to get a flavor, no need to review every case. The `underscoreMangler` function that generates these is in [#101](https://github.com/wgsl-tooling-wg/wesl-js/pull/101)