### PR TITLE
emit imported const_asserts after the root module

### DIFF
--- a/src/test-cases-json/conditionalTranslationCases.json
+++ b/src/test-cases-json/conditionalTranslationCases.json
@@ -268,8 +268,8 @@
       "./foo.wgsl": "const_assert 0 < 1; fn func() {}",
       "./bar.wgsl": "const_assert 1 < 2; fn func() {}"
     },
-    "expectedWgsl": "const_assert 0 < 1; fn main() { func(); } fn func() {}",
-    "underscoreWgsl": "const_assert 0 < 1; fn main() { package_foo_func(); } fn package_foo_func() {}"
+    "expectedWgsl": "fn main() { func(); } const_assert 0 < 1; fn func() {}",
+    "underscoreWgsl": "fn main() { package_foo_func(); } const_assert 0 < 1; fn package_foo_func() {}"
   },
   {
     "name": "double conditional import of const_assert",
@@ -278,8 +278,8 @@
       "./main.wgsl": "fn main() { @if(true) package::foo::func(); @if(true) package::foo::bar(); }",
       "./foo.wgsl": "const_assert 0 < 1; fn func() {} fn bar() {}"
     },
-    "expectedWgsl": "const_assert 0 < 1; fn main() { func(); bar(); } fn func() {} fn bar() {}",
-    "underscoreWgsl": "const_assert 0 < 1; fn main() { package_foo_func(); package_foo_bar(); } fn package_foo_func() {} fn package_foo_bar() {}"
+    "expectedWgsl": "fn main() { func(); bar(); } const_assert 0 < 1; fn func() {} fn bar() {}",
+    "underscoreWgsl": "fn main() { package_foo_func(); package_foo_bar(); } const_assert 0 < 1; fn package_foo_func() {} fn package_foo_bar() {}"
   },
   {
     "name": "conditional transitive const",

--- a/src/test-cases/ConditionalTranslationCases.ts
+++ b/src/test-cases/ConditionalTranslationCases.ts
@@ -503,17 +503,17 @@ export const conditionalTranslationCases: WgslTestSrc[] = [
         fn func() {}`,
     },
     expectedWgsl: `
-      const_assert 0 < 1;
       fn main() {
         func();
       }
+      const_assert 0 < 1;
       fn func() {}`,
     underscoreWgsl: `
-      const_assert 0 < 1;
       fn main() {
         package_foo_func();
       }
 
+      const_assert 0 < 1;
       fn package_foo_func() {}`,
   },
   {
@@ -535,20 +535,20 @@ export const conditionalTranslationCases: WgslTestSrc[] = [
       `,
     },
     expectedWgsl: `
-      const_assert 0 < 1;
       fn main() {
         func();
         bar();
       }
+      const_assert 0 < 1;
       fn func() {}
       fn bar() {}
     `,
     underscoreWgsl: `
-      const_assert 0 < 1;
       fn main() {
         package_foo_func();
         package_foo_bar();
       }
+      const_assert 0 < 1;
       fn package_foo_func() {}
       fn package_foo_bar() {}
     `,


### PR DESCRIPTION
When implementing hoisting of requires/enable from imported modules I found it convenient to put the imported directives first, then the root module, and then the hoisted const asserts.

I think wesl-rs is probably indifferent to the order, since you sort declarations...